### PR TITLE
VS2026 STL <complex> is using a runtime global (isa_available) which …

### DIFF
--- a/clang/lib/Basic/Targets/SPIR.cpp
+++ b/clang/lib/Basic/Targets/SPIR.cpp
@@ -84,6 +84,22 @@ void SPIR64TargetInfo::getTargetDefines(const LangOptions &Opts,
   DefineStd(Builder, "SPIR64", Opts);
 }
 
+bool WindowsX86_64_SPIR64TargetInfo::initFeatureMap(
+    llvm::StringMap<bool> &Features, DiagnosticsEngine &Diags, StringRef CPU,
+    const std::vector<std::string> &FeaturesVec) const {
+  // When SYCL device code compiles MSVC STL headers, the headers take the
+  // x86 intrinsics path under _M_X64 (defined by MicrosoftX86_64_SPIR64-
+  // TargetInfo). Those intrinsics require sse/sse2 in the target feature set;
+  // without them, any function-level __target__ attribute that recomputes
+  // features (e.g. VS2026 <complex>'s [[gnu::target("fma")]] on
+  // _Sqr_error_x86_x64_fma) strips the baseline and the function's sse2
+  // intrinsic calls (_mm_set_sd, _mm_store_sd, ...) fail to compile. Mirror
+  // X86TargetInfo's "x86_64 always has SSE2" assumption.
+  Features["sse"] = true;
+  Features["sse2"] = true;
+  return SPIR64TargetInfo::initFeatureMap(Features, Diags, CPU, FeaturesVec);
+}
+
 void BaseSPIRVTargetInfo::getTargetDefines(const LangOptions &Opts,
                                            MacroBuilder &Builder) const {
   DefineStd(Builder, "SPIRV", Opts);

--- a/clang/lib/Basic/Targets/SPIR.cpp
+++ b/clang/lib/Basic/Targets/SPIR.cpp
@@ -87,14 +87,9 @@ void SPIR64TargetInfo::getTargetDefines(const LangOptions &Opts,
 bool WindowsX86_64_SPIR64TargetInfo::initFeatureMap(
     llvm::StringMap<bool> &Features, DiagnosticsEngine &Diags, StringRef CPU,
     const std::vector<std::string> &FeaturesVec) const {
-  // When SYCL device code compiles MSVC STL headers, the headers take the
-  // x86 intrinsics path under _M_X64 (defined by MicrosoftX86_64_SPIR64-
-  // TargetInfo). Those intrinsics require sse/sse2 in the target feature set;
-  // without them, any function-level __target__ attribute that recomputes
-  // features (e.g. VS2026 <complex>'s [[gnu::target("fma")]] on
-  // _Sqr_error_x86_x64_fma) strips the baseline and the function's sse2
-  // intrinsic calls (_mm_set_sd, _mm_store_sd, ...) fail to compile. Mirror
-  // X86TargetInfo's "x86_64 always has SSE2" assumption.
+  // Mirror X86TargetInfo's "x86_64 always has SSE2" baseline: the matching
+  // _M_X64 macro makes MSVC STL headers take the x86 intrinsics path, whose
+  // _mm_* intrinsics require sse/sse2 in the target feature set.
   Features["sse"] = true;
   Features["sse2"] = true;
   return SPIR64TargetInfo::initFeatureMap(Features, Diags, CPU, FeaturesVec);

--- a/clang/lib/Basic/Targets/SPIR.h
+++ b/clang/lib/Basic/Targets/SPIR.h
@@ -395,6 +395,11 @@ public:
     return (CC == CC_SpirFunction || CC == CC_DeviceKernel) ? CCCR_OK
                                     : CCCR_Warning;
   }
+
+  bool initFeatureMap(llvm::StringMap<bool> &Features, DiagnosticsEngine &Diags,
+                      StringRef CPU,
+                      const std::vector<std::string> &FeaturesVec)
+      const override;
 };
 
 // x86-64 SPIR64 Windows Visual Studio target

--- a/sycl/include/sycl/stl_wrappers/complex
+++ b/sycl/include/sycl/stl_wrappers/complex
@@ -18,20 +18,18 @@
 // Provide __isa_available for MSVC device code BEFORE including STL headers.
 // Must come before #include_next so our definition is seen first.
 #if defined(__SYCL_DEVICE_ONLY__) && defined(_MSC_VER)
-// VS2026 STL headers use __isa_available (a runtime global variable) to detect
-// CPU features. SYCL device code cannot access host runtime globals, so
-// provide a workaround. 
-// __isa_available is an integer "level" the MSVC STL compares against named
-// constants in <vcruntime.h> (e.g. __ISA_AVAILABLE_AVX2 == 5,
-// __ISA_AVAILABLE_AVX512 == 6). We pick a value greater than any currently
-// defined level so every feature gate in the STL evaluates "available."
-#ifndef __SYCL_MSVC_ISA_AVAILABLE_DEVICE_STUB
-#define __SYCL_MSVC_ISA_AVAILABLE_DEVICE_STUB 10 // > __ISA_AVAILABLE_AVX512
-#endif
+// VS2026 STL headers use __isa_available (a runtime global variable) to
+// detect CPU features: `if (__isa_available >= _Stl_isa_available_avx2) ...`.
+// SYCL device code cannot access host runtime globals, so provide a device-
+// side definition. The VALUE of this variable only steers the STL's runtime
+// feature dispatch — both branches of the dispatch compile either way. We
+// pick __ISA_AVAILABLE_X86 (== 0, the baseline in <isa_availability.h>),
+// which matches a spir64 device's reality (no x86 ISA), and so selects the
+// STL's scalar fallback paths if these dispatches are ever reached.
 extern "C" int __isa_available
     __attribute__((sycl_global_var))
     __attribute__((weak))
-    = __SYCL_MSVC_ISA_AVAILABLE_DEVICE_STUB;
+    = 0;
 #endif // defined(__SYCL_DEVICE_ONLY__) && defined(_MSC_VER)
 
 // Include real STL <complex> header - the next one from the include search

--- a/sycl/include/sycl/stl_wrappers/complex
+++ b/sycl/include/sycl/stl_wrappers/complex
@@ -18,24 +18,21 @@
 // Provide __isa_available for MSVC device code BEFORE including STL headers.
 // Must come before #include_next so our definition is seen first.
 #if defined(__SYCL_DEVICE_ONLY__) && defined(_MSC_VER)
-// VS2022+ STL headers use __isa_available (a runtime global variable) to detect
-// CPU features. SYCL device code cannot access host runtime globals. Provide a
-// definition that assumes AVX2+ features are available (value >= 5 enables FMA
-// optimizations). Must be non-const to match STL's 'extern int' declaration.
-// sycl_global_var attribute suppresses the "non-const global in device code"
-// diagnostic.
-extern "C" int __isa_available __attribute__((sycl_global_var)) = 10;
-#endif // defined(__SYCL_DEVICE_ONLY__) && defined(_MSC_VER)
-
-// VS2026's <complex> annotates _Sqr_error_x86_x64_fma with
-// [[__gnu__::__target__("fma")]]. clang/icx treats target(...) as REPLACING the
-// function's target feature set (not augmenting it), so sse2 drops out and the
-// function's _mm_set_sd / _mm_store_sd calls fail to compile on spir64. Augment
-// the target string so sse2 (and sse) stay in the feature set.
-#if defined(__SYCL_DEVICE_ONLY__) && defined(_MSC_VER)
-#pragma push_macro("__target__")
-#define __target__(x) __target__(x ",sse2,sse")
+// VS2026 STL headers use __isa_available (a runtime global variable) to detect
+// CPU features. SYCL device code cannot access host runtime globals, so
+// provide a workaround. 
+// __isa_available is an integer "level" the MSVC STL compares against named
+// constants in <vcruntime.h> (e.g. __ISA_AVAILABLE_AVX2 == 5,
+// __ISA_AVAILABLE_AVX512 == 6). We pick a value greater than any currently
+// defined level so every feature gate in the STL evaluates "available."
+#ifndef __SYCL_MSVC_ISA_AVAILABLE_DEVICE_STUB
+#define __SYCL_MSVC_ISA_AVAILABLE_DEVICE_STUB 10 // > __ISA_AVAILABLE_AVX512
 #endif
+extern "C" int __isa_available
+    __attribute__((sycl_global_var))
+    __attribute__((weak))
+    = __SYCL_MSVC_ISA_AVAILABLE_DEVICE_STUB;
+#endif // defined(__SYCL_DEVICE_ONLY__) && defined(_MSC_VER)
 
 // Include real STL <complex> header - the next one from the include search
 // directories.
@@ -49,10 +46,6 @@ extern "C" int __isa_available __attribute__((sycl_global_var)) = 10;
 // where the following would result in the <complex> we want. This is obviously
 // hacky, but the best we can do...
 #include <../include/complex>
-#endif
-
-#if defined(__SYCL_DEVICE_ONLY__) && defined(_MSC_VER)
-#pragma pop_macro("__target__")
 #endif
 
 #if defined(__NVPTX__) || defined(__AMDGCN__)

--- a/sycl/include/sycl/stl_wrappers/complex
+++ b/sycl/include/sycl/stl_wrappers/complex
@@ -15,6 +15,28 @@
 
 #pragma once
 
+// Provide __isa_available for MSVC device code BEFORE including STL headers.
+// Must come before #include_next so our definition is seen first.
+#if defined(__SYCL_DEVICE_ONLY__) && defined(_MSC_VER)
+// VS2022+ STL headers use __isa_available (a runtime global variable) to detect
+// CPU features. SYCL device code cannot access host runtime globals. Provide a
+// definition that assumes AVX2+ features are available (value >= 5 enables FMA
+// optimizations). Must be non-const to match STL's 'extern int' declaration.
+// sycl_global_var attribute suppresses the "non-const global in device code"
+// diagnostic.
+extern "C" int __isa_available __attribute__((sycl_global_var)) = 10;
+#endif // defined(__SYCL_DEVICE_ONLY__) && defined(_MSC_VER)
+
+// VS2026's <complex> annotates _Sqr_error_x86_x64_fma with
+// [[__gnu__::__target__("fma")]]. clang/icx treats target(...) as REPLACING the
+// function's target feature set (not augmenting it), so sse2 drops out and the
+// function's _mm_set_sd / _mm_store_sd calls fail to compile on spir64. Augment
+// the target string so sse2 (and sse) stay in the feature set.
+#if defined(__SYCL_DEVICE_ONLY__) && defined(_MSC_VER)
+#pragma push_macro("__target__")
+#define __target__(x) __target__(x ",sse2,sse")
+#endif
+
 // Include real STL <complex> header - the next one from the include search
 // directories.
 #if defined(__has_include_next)
@@ -27,6 +49,10 @@
 // where the following would result in the <complex> we want. This is obviously
 // hacky, but the best we can do...
 #include <../include/complex>
+#endif
+
+#if defined(__SYCL_DEVICE_ONLY__) && defined(_MSC_VER)
+#pragma pop_macro("__target__")
 #endif
 
 #if defined(__NVPTX__) || defined(__AMDGCN__)


### PR DESCRIPTION
…is not available on GPU. This fix masks and works around it.